### PR TITLE
Move docker login to start of pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ jobs:
       with:
         skipClusterCreation: "true"
 
+    - name: Docker login
+      run: |
+        echo ${{ secrets.DOCKER_AUTH }} | docker login --username kbstci --password-stdin ghcr.io
+
     - name: Build image
       if: startsWith(github.ref, 'refs/tags/v') == false
       run: make build-image
@@ -25,10 +29,6 @@ jobs:
 
     - name: Test image
       run: make test-image
-
-    - name: Docker login
-      run: |
-        echo ${{ secrets.DOCKER_AUTH }} | docker login --username kbstci --password-stdin ghcr.io
 
     - name: Push image
       if: startsWith(github.ref, 'refs/tags/v') == false


### PR DESCRIPTION
While the repo is public before the EKS-D launch, the pull also
needs to be authenticated.